### PR TITLE
Added script to start container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+set -e
+
+# Settings from environment
+UDACITY_SOURCE=${UDACITY_SOURCE:-`pwd`}
+UDACITY_IMAGE=${UDACITY_IMAGE:-bydavy/carnd-capstone}
+CONTAINER_NAME="udacity_carnd"
+
+if [ "$(docker ps -a | grep ${CONTAINER_NAME})" ]; then
+  echo "Attaching to running container..."
+  docker exec -it ${CONTAINER_NAME} bash $@
+else
+  docker run --name ${CONTAINER_NAME} --rm -it -p 4567:4567 -v "${UDACITY_SOURCE}:/udacity" ${UDACITY_IMAGE} $@
+fi


### PR DESCRIPTION
run.sh will start the container. Nothing else is required on Linux or MacOS, as long as Docker is installed. Hopefully, this should help people as they don't have to manage or install any dependencies.